### PR TITLE
Support Cargo.lock analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Static Analysis Library for Containers
 - Detect OS
 - Extract OS packages
 - Extract libraries used by an application
-  - Bundler, Composer, npm, Pipenv
+  - Bundler, Composer, npm, Pipenv, Cargo
 
 ## Example
 See `cmd/fanal/`
@@ -35,6 +35,7 @@ import (
 	_ "github.com/knqyf263/fanal/analyzer/library/composer"
 	_ "github.com/knqyf263/fanal/analyzer/library/npm"
 	_ "github.com/knqyf263/fanal/analyzer/library/pipenv"
+	_ "github.com/knqyf263/fanal/analyzer/library/cargo"
 	_ "github.com/knqyf263/fanal/analyzer/os/alpine"
 	_ "github.com/knqyf263/fanal/analyzer/os/amazonlinux"
 	_ "github.com/knqyf263/fanal/analyzer/os/debianbase"

--- a/analyzer/library/cargo/cargo.go
+++ b/analyzer/library/cargo/cargo.go
@@ -1,0 +1,43 @@
+package cargo
+
+import (
+	"bytes"
+	"path/filepath"
+
+	"github.com/knqyf263/fanal/analyzer"
+	"github.com/knqyf263/fanal/extractor"
+	"github.com/knqyf263/fanal/utils"
+	"github.com/knqyf263/go-dep-parser/pkg/cargo"
+	"github.com/knqyf263/go-dep-parser/pkg/types"
+	"golang.org/x/xerrors"
+)
+
+func init() {
+	analyzer.RegisterLibraryAnalyzer(&cargoLibraryAnalyzer{})
+}
+
+type cargoLibraryAnalyzer struct{}
+
+func (a cargoLibraryAnalyzer) Analyze(fileMap extractor.FileMap) (map[analyzer.FilePath][]types.Library, error) {
+	libMap := map[analyzer.FilePath][]types.Library{}
+	requiredFiles := a.RequiredFiles()
+
+	for filename, content := range fileMap {
+		basename := filepath.Base(filename)
+		if !utils.StringInSlice(basename, requiredFiles) {
+			continue
+		}
+
+		r := bytes.NewBuffer(content)
+		libs, err := cargo.Parse(r)
+		if err != nil {
+			return nil, xerrors.Errorf("invalid Cargo.lock format: %w", err)
+		}
+		libMap[analyzer.FilePath(filename)] = libs
+	}
+	return libMap, nil
+}
+
+func (a cargoLibraryAnalyzer) RequiredFiles() []string {
+	return []string{"Cargo.lock"}
+}

--- a/cmd/fanal/main.go
+++ b/cmd/fanal/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/knqyf263/fanal/analyzer"
 	_ "github.com/knqyf263/fanal/analyzer/library/bundler"
+	_ "github.com/knqyf263/fanal/analyzer/library/cargo"
 	_ "github.com/knqyf263/fanal/analyzer/library/composer"
 	_ "github.com/knqyf263/fanal/analyzer/library/npm"
 	_ "github.com/knqyf263/fanal/analyzer/library/pipenv"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/docker v0.0.0-20180924202107-a9c061deec0f
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/genuinetools/reg v0.16.0
-	github.com/knqyf263/go-dep-parser v0.0.0-20190429154931-c377a5391790
+	github.com/knqyf263/go-dep-parser v0.0.0-20190511063217-d5d543bfc261
 	github.com/knqyf263/go-rpmdb v0.0.0-20190501070121-10a1c42a10dc
 	github.com/knqyf263/nested v0.0.1
 	github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ cloud.google.com/go v0.37.4 h1:glPeL3BQJsbF6aIIYfZizMwc5LTYz250bDMjttbBGAU=
 cloud.google.com/go v0.37.4/go.mod h1:NHPJ89PdicEuT9hdPXMROBD91xc5uRDxsMtSB16k7hw=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GoogleCloudPlatform/docker-credential-gcr v1.5.0 h1:wykTgKwhVr2t2qs+xI020s6W5dt614QqCHV+7W9dg64=
 github.com/GoogleCloudPlatform/docker-credential-gcr v1.5.0/go.mod h1:BB1eHdMLYEFuFdBlRMb0N7YGVdM5s6Pt0njxgvfbGGs=
@@ -95,6 +96,8 @@ github.com/knqyf263/berkeleydb v0.0.0-20190501065933-fafe01fb9662 h1:UGS0RbPHwXJ
 github.com/knqyf263/berkeleydb v0.0.0-20190501065933-fafe01fb9662/go.mod h1:bu1CcN4tUtoRcI/B/RFHhxMNKFHVq/c3SV+UTyduoXg=
 github.com/knqyf263/go-dep-parser v0.0.0-20190429154931-c377a5391790 h1:c02gG0yRNr25lcLOH+678SuuxxMUq36i48PQnmAweWk=
 github.com/knqyf263/go-dep-parser v0.0.0-20190429154931-c377a5391790/go.mod h1:CtT+dtv38jSz5EYYCX21LgtVXP+J3soF2fzQT8lHCfY=
+github.com/knqyf263/go-dep-parser v0.0.0-20190511063217-d5d543bfc261 h1:RPgPsbEsYj6LuOjZnKl2DvbfodNWRuWKZfWJkrD7l8s=
+github.com/knqyf263/go-dep-parser v0.0.0-20190511063217-d5d543bfc261/go.mod h1:gSiqSkOFPstUZu/qZ4wnNJS69PtQQnPl397vxKHJ5mQ=
 github.com/knqyf263/go-rpmdb v0.0.0-20190501070121-10a1c42a10dc h1:pumO9pqmRAjvic6oove22RGh9wDZQnj96XQjJSbSEPs=
 github.com/knqyf263/go-rpmdb v0.0.0-20190501070121-10a1c42a10dc/go.mod h1:MrSSvdMpTSymaQWk1yFr9sxFSyQmKMj6jkbvGrchBV8=
 github.com/knqyf263/nested v0.0.1 h1:Sv26CegUMhjt19zqbBKntjwESdxe5hxVPSk0+AKjdUc=


### PR DESCRIPTION
Support Cargo.lock for Rust.

### TEST 

```
$ go build -o fanal cmd/fanal/main.go
$ docker save trivy-ci-test:latest -o test.tar
$ ./fanal -f test.tar
{Name:3.7.1 Family:alpine}
Packages: 58
node-app/package-lock.json: 13
python-app/Pipfile.lock: 55
ruby-app/Gemfile.lock: 54
rust-app/Cargo.lock: 74
```