### PR TITLE
Support poetry.lock file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Static Analysis Library for Containers
 - Detect OS
 - Extract OS packages
 - Extract libraries used by an application
-  - Bundler, Composer, npm, Pipenv, Cargo
+  - Bundler, Composer, npm, Yarn, Pipenv, Poetry, Cargo
 
 ## Example
 See `cmd/fanal/`
@@ -35,6 +35,8 @@ import (
 	_ "github.com/knqyf263/fanal/analyzer/library/composer"
 	_ "github.com/knqyf263/fanal/analyzer/library/npm"
 	_ "github.com/knqyf263/fanal/analyzer/library/pipenv"
+	_ "github.com/knqyf263/fanal/analyzer/library/poetry"
+	_ "github.com/knqyf263/fanal/analyzer/library/yarn"
 	_ "github.com/knqyf263/fanal/analyzer/library/cargo"
 	_ "github.com/knqyf263/fanal/analyzer/os/alpine"
 	_ "github.com/knqyf263/fanal/analyzer/os/amazonlinux"

--- a/analyzer/library/poetry/poetry.go
+++ b/analyzer/library/poetry/poetry.go
@@ -1,0 +1,43 @@
+package poetry
+
+import (
+	"bytes"
+	"path/filepath"
+
+	"github.com/knqyf263/fanal/analyzer"
+	"github.com/knqyf263/fanal/extractor"
+	"github.com/knqyf263/fanal/utils"
+	"github.com/knqyf263/go-dep-parser/pkg/poetry"
+	"github.com/knqyf263/go-dep-parser/pkg/types"
+	"golang.org/x/xerrors"
+)
+
+func init() {
+	analyzer.RegisterLibraryAnalyzer(&poetryLibraryAnalyzer{})
+}
+
+type poetryLibraryAnalyzer struct{}
+
+func (a poetryLibraryAnalyzer) Analyze(fileMap extractor.FileMap) (map[analyzer.FilePath][]types.Library, error) {
+	libMap := map[analyzer.FilePath][]types.Library{}
+	requiredFiles := a.RequiredFiles()
+
+	for filename, content := range fileMap {
+		basename := filepath.Base(filename)
+		if !utils.StringInSlice(basename, requiredFiles) {
+			continue
+		}
+
+		r := bytes.NewBuffer(content)
+		libs, err := poetry.Parse(r)
+		if err != nil {
+			return nil, xerrors.Errorf("invalid poetry.lock format: %w", err)
+		}
+		libMap[analyzer.FilePath(filename)] = libs
+	}
+	return libMap, nil
+}
+
+func (a poetryLibraryAnalyzer) RequiredFiles() []string {
+	return []string{"poetry.lock"}
+}

--- a/cmd/fanal/main.go
+++ b/cmd/fanal/main.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/knqyf263/fanal/analyzer/library/composer"
 	_ "github.com/knqyf263/fanal/analyzer/library/npm"
 	_ "github.com/knqyf263/fanal/analyzer/library/pipenv"
+	_ "github.com/knqyf263/fanal/analyzer/library/poetry"
 	_ "github.com/knqyf263/fanal/analyzer/library/yarn"
 	_ "github.com/knqyf263/fanal/analyzer/os/alpine"
 	_ "github.com/knqyf263/fanal/analyzer/os/amazonlinux"


### PR DESCRIPTION

```
$ go build -o fanal cmd/fanal/main.go
$ docker save trivy-ci-test:latest -o poetry.tar
$ ./fanal -f poetry.tar
{Name:3.7.1 Family:alpine}
via image Packages: 65
via file Packages: 83
poetry-app/poetry.lock: 11
yarn-app/yarn.lock: 12
ruby-app/Gemfile.lock: 54
rust-app/Cargo.lock: 74
php-app/composer.lock: 14
node-app/package-lock.json: 13
python-app/Pipfile.lock: 55
```