### PR TITLE
Improves package analysis errors usability

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -25,6 +25,8 @@ var (
 	ErrUnknownOS = xerrors.New("Unknown OS")
 	// ErrPkgAnalysis occurs when the analysis of packages is failed.
 	ErrPkgAnalysis = xerrors.New("Failed to analyze packages")
+	// ErrNoPkgsDetected occurs when the required files for an OS package manager are not detected
+	ErrNoPkgsDetected = xerrors.New("No packages detected")
 )
 
 type OSAnalyzer interface {
@@ -158,10 +160,12 @@ func GetOS(filesMap extractor.FileMap) (OS, error) {
 func GetPackages(filesMap extractor.FileMap) ([]Package, error) {
 	for _, analyzer := range pkgAnalyzers {
 		pkgs, err := analyzer.Analyze(filesMap)
-		if err != nil {
+
+		// Differentiate between a package manager not being found and another error
+		if err != nil && err == ErrNoPkgsDetected {
 			continue
 		}
-		return pkgs, nil
+		return pkgs, err
 	}
 	return nil, ErrPkgAnalysis
 }

--- a/analyzer/pkg/apk/apk.go
+++ b/analyzer/pkg/apk/apk.go
@@ -5,8 +5,6 @@ import (
 	"bytes"
 	"log"
 
-	"github.com/pkg/errors"
-
 	"github.com/knqyf263/fanal/analyzer"
 	"github.com/knqyf263/fanal/extractor"
 
@@ -33,7 +31,7 @@ func (a alpinePkgAnalyzer) Analyze(fileMap extractor.FileMap) (pkgs []analyzer.P
 		detected = true
 	}
 	if !detected {
-		return pkgs, errors.New("No package detected")
+		return pkgs, analyzer.ErrNoPkgsDetected
 	}
 	return pkgs, nil
 }

--- a/analyzer/pkg/dpkg/dpkg.go
+++ b/analyzer/pkg/dpkg/dpkg.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	mapset "github.com/deckarep/golang-set"
-	"golang.org/x/xerrors"
 
 	"github.com/knqyf263/fanal/analyzer"
 	"github.com/knqyf263/fanal/extractor"
@@ -39,7 +38,7 @@ func (a debianPkgAnalyzer) Analyze(fileMap extractor.FileMap) (pkgs []analyzer.P
 		detected = true
 	}
 	if !detected {
-		return pkgs, xerrors.New("no package detected")
+		return pkgs, analyzer.ErrNoPkgsDetected
 	}
 	return pkgs, nil
 }

--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"golang.org/x/xerrors"
-
 	"github.com/knqyf263/fanal/analyzer"
 	"github.com/knqyf263/fanal/extractor"
 	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
@@ -31,7 +29,7 @@ func (a rpmPkgAnalyzer) Analyze(fileMap extractor.FileMap) (pkgs []analyzer.Pack
 		detected = true
 	}
 	if !detected {
-		return nil, xerrors.New("No package detected")
+		return nil, analyzer.ErrNoPkgsDetected
 	}
 	return pkgs, err
 }

--- a/analyzer/pkg/rpmcmd/rpm.go
+++ b/analyzer/pkg/rpmcmd/rpm.go
@@ -2,7 +2,6 @@ package rpmcmd
 
 import (
 	"bufio"
-	"errors"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -35,7 +34,7 @@ func (a rpmCmdPkgAnalyzer) Analyze(fileMap extractor.FileMap) (pkgs []analyzer.P
 		detected = true
 	}
 	if !detected {
-		return pkgs, errors.New("No package detected")
+		return pkgs, analyzer.ErrNoPkgsDetected
 	}
 	return pkgs, err
 }


### PR DESCRIPTION
My original issue was that I was trying to run `trivy` on a OS X based system on a CentOS based image. I was getting back an "Unknown OS" error even though `trivy` should have considered my image having a known OS. After some debugging, I discovered that all errors were being suppressed from the different package analyzers and that the issue was that the `rpm` command was not locally installed on my system.

Master build run on an RPM based distro:
```bash
./trivy centos:7
2019-06-29T12:32:55.138-0700	INFO	Updating vulnerability database...
2019-06-29T12:32:59.893-0700	FATAL	error in image scan: failed to scan image: failed to analyze OS packages: Unknown OS
```

Branch build run on RPM based distro:
```bash
./trivy centos:7
2019-06-29T12:33:15.886-0700	INFO	Updating vulnerability database...
2019-06-29T12:33:20.486-0700	FATAL	error in image scan: failed to scan image: failed to analyze OS packages: exec: "rpm": executable file not found in $PATH
```

Branch build with an unknown OS (archlinux):
```bash
./trivy archlinux/base:latest
2019-06-29T12:35:15.161-0700	INFO	Updating vulnerability database...
2019-06-29T12:35:15.564-0700	WARN	You should avoid using the :latest tag as it is cached. You need to specify '--clear-cache' option when :latest image is changed
2019-06-29T12:35:32.090-0700	FATAL	error in image scan: failed to scan image: failed to analyze OS: Unknown OS
```

Commit Info:
- Adds a new analyzer error for "no packages detected"
- Package analyzers now return the common "no packages detected" error
- Returned errors from the package analyzers are checked against the
  common "no packages detected" errors and filters those out. Other
  errors will now be passed back to the user for debugging.